### PR TITLE
Skip unused distributions in entropy-weighting bisection

### DIFF
--- a/src/eweight.c
+++ b/src/eweight.c
@@ -32,7 +32,7 @@ eweight_target_f(double Neff, void *params, double *ret_fx)
 
   p7_hmm_CopyParameters(p->hmm, p->h2);
   p7_hmm_Scale(p->h2, Neff / (double) p->h2->nseq);
-  p7_ParameterEstimation(p->h2, p->pri);
+  p7_ParameterEstimation_MatchOnly(p->h2, p->pri);
   *ret_fx = p7_MeanMatchRelativeEntropy(p->h2, p->bg) - p->etarget;
   return eslOK;
 }
@@ -107,7 +107,7 @@ eweight_target_exp_f(double exp, void *params, double *ret_fx)
 
   p7_hmm_CopyParameters(p->hmm, p->h2);
   p7_hmm_ScaleExponential(p->h2, exp);
-  p7_ParameterEstimation(p->h2, p->pri);
+  p7_ParameterEstimation_MatchOnly(p->h2, p->pri);
   *ret_fx = p7_MeanMatchRelativeEntropy(p->h2, p->bg) - p->etarget;
   return eslOK;
 }

--- a/src/hmmer.h
+++ b/src/hmmer.h
@@ -1588,6 +1588,7 @@ extern P7_PRIOR  *p7_prior_CreateLaplace(const ESL_ALPHABET *abc);
 extern void       p7_prior_Destroy(P7_PRIOR *pri);
 
 extern int        p7_ParameterEstimation(P7_HMM *hmm, const P7_PRIOR *pri);
+extern int        p7_ParameterEstimation_MatchOnly(P7_HMM *hmm, const P7_PRIOR *pri);
 
 /* p7_profile.c */
 extern P7_PROFILE    *p7_profile_Create(int M, const ESL_ALPHABET *abc);

--- a/src/p7_prior.c
+++ b/src/p7_prior.c
@@ -277,6 +277,30 @@ p7_prior_Destroy(P7_PRIOR *pri)
 
 
 
+/* Function:  p7_ParameterEstimation_MatchOnly()
+ * Purpose:   Like p7_ParameterEstimation(), but only the match emissions.
+ *            For callers (entropy weighting) that only read hmm->mat.
+ */
+int
+p7_ParameterEstimation_MatchOnly(P7_HMM *hmm, const P7_PRIOR *pri)
+{
+  int   k;
+  double c[p7_MAXABET];
+  double p[p7_MAXABET];
+
+  if (pri==NULL) return p7_hmm_Renormalize(hmm);
+
+  for (k = 1; k <= hmm->M; k++) {
+    esl_vec_F2D(hmm->mat[k], hmm->abc->K, c);
+    esl_mixdchlet_MPParameters(pri->em, c, p);
+    esl_vec_D2F(p, hmm->abc->K, hmm->mat[k]);
+  }
+  esl_vec_FSet(hmm->mat[0], hmm->abc->K, 0.);
+  hmm->mat[0][0] = 1.0;
+  return eslOK;
+}
+
+
 /* Function:  p7_ParameterEstimation()
  * Incept:    SRE, Sat Mar 24 10:15:37 2007 [Janelia]
  *


### PR DESCRIPTION
eweight_target_f() and eweight_target_exp_f() call p7_ParameterEstimation(), which reparameterizes match/insert/delete transitions and both emission distributions. 

Only hmm->mat is read, by p7_MeanMatchRelativeEntropy(); the other four are discarded on every root-finder iteration (~10-15 per model).

Add p7_ParameterEstimation_MatchOnly() and call it from both callbacks. Cuts esl_mixdchlet_MPParameters() calls in the bisection from ~5M to ~M per iteration.

bathbuild over 5232 dipteraODB12 alignments, serial: 859.6s -> 778.3s (1.10x). Output byte-identical on that corpus
and across the build/weighting/prior option matrix.